### PR TITLE
Updated yaml script to decode service account json file

### DIFF
--- a/.github/workflows/pythonTestscript.yml
+++ b/.github/workflows/pythonTestscript.yml
@@ -25,7 +25,9 @@ jobs:
        
       - name: Write service_account.json from secret
         run: |
-          echo "${{ secrets.SERVICE_ACCOUNT }}" > service_account.json 
+          echo "$SERVICE_ACCOUNT" | base64 --decode > SERVICE_ACCOUNT.json
+        env:
+          SERVICE_ACCOUNT: ${{ secrets.SERVICE_ACCOUNT }}
 
       - name: Run GoogleRunner
         env:


### PR DESCRIPTION
Encoded the service account json file to fix the issue of the actions workflow failing due to json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 2 column 3 (char 4). 
